### PR TITLE
Revert "using updated docker base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java:v8.161
+FROM ubirch/java
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION


### PR DESCRIPTION
Reverts ubirch/ubirch-poc-manager#25

new docker image was not published yet