### PR TITLE
UNG-2089 - Namespaced UbirchId/TenantId/DeviceId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
         <!-- Namespaced UUIDs -->
         <dependency>
             <groupId>com.47deg</groupId>
-            <artifactId>memeid</artifactId>
+            <artifactId>memeid4s_${scala.compat.version}</artifactId>
             <version>${memeid.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
         <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
         <maven-scalafmt.version>1.0.1614576627.86a5663</maven-scalafmt.version>
+        <memeid.version>0.1</memeid.version>
         <!-- plugins -->
 
     </properties>
@@ -465,6 +466,13 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>
+        </dependency>
+
+        <!-- Namespaced UUIDs -->
+        <dependency>
+            <groupId>com.47deg</groupId>
+            <artifactId>memeid</artifactId>
+            <version>${memeid.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/scala/com/ubirch/controllers/TenantAdminController.scala
+++ b/src/main/scala/com/ubirch/controllers/TenantAdminController.scala
@@ -128,7 +128,7 @@ class TenantAdminController @Inject() (
         retrieveTenantFromToken(token).flatMap {
           case Right(tenant: Tenant) =>
             pocTable
-              .getAllPocsByTenantId(tenant.id.value)
+              .getAllPocsByTenantId(tenant.id)
               .map(toJson)
               .onErrorHandle(ex =>
                 InternalServerError(NOK.serverError(

--- a/src/main/scala/com/ubirch/db/tables/PocTable.scala
+++ b/src/main/scala/com/ubirch/db/tables/PocTable.scala
@@ -3,6 +3,7 @@ package com.ubirch.db.tables
 import com.google.inject.Inject
 import com.ubirch.db.context.QuillJdbcContext
 import com.ubirch.models.poc.{ Completed, Poc, PocStatus, Status }
+import com.ubirch.models.tenant.TenantId
 import io.getquill.{ Insert, Update }
 import monix.eval.Task
 
@@ -21,7 +22,7 @@ trait PocRepository {
 
   def getPoc(pocId: UUID): Task[Option[Poc]]
 
-  def getAllPocsByTenantId(tenantId: UUID): Task[List[Poc]]
+  def getAllPocsByTenantId(tenantId: TenantId): Task[List[Poc]]
 
   def getAllUncompletedPocs(): Task[List[Poc]]
 }
@@ -62,7 +63,7 @@ class PocTable @Inject() (quillJdbcContext: QuillJdbcContext) extends PocReposit
       querySchema[Poc]("poc_manager.poc_table").filter(_.id == lift(pocId))
     }
 
-  private def getAllPocsByTenantIdQuery(tenantId: UUID) =
+  private def getAllPocsByTenantIdQuery(tenantId: TenantId) =
     quote {
       querySchema[Poc]("poc_manager.poc_table").filter(_.tenantId == lift(tenantId))
     }
@@ -96,8 +97,8 @@ class PocTable @Inject() (quillJdbcContext: QuillJdbcContext) extends PocReposit
 
   override def getPoc(pocId: UUID): Task[Option[Poc]] = Task(run(getPocQuery(pocId))).map(_.headOption)
 
-  override def getAllPocsByTenantId(tenantId: UUID): Task[List[Poc]] =
-    Task(run(getAllPocsByTenantIdQuery(tenantId: UUID)))
+  override def getAllPocsByTenantId(tenantId: TenantId): Task[List[Poc]] =
+    Task(run(getAllPocsByTenantIdQuery(tenantId)))
 
   def getAllUncompletedPocs(): Task[List[Poc]] = Task(run(getAllPocsWithoutStatusQuery(Completed)))
 }

--- a/src/main/scala/com/ubirch/models/NamespacedUUID.scala
+++ b/src/main/scala/com/ubirch/models/NamespacedUUID.scala
@@ -1,0 +1,20 @@
+package com.ubirch.models
+
+import io.getquill.MappedEncoding
+import memeid4s.UUID
+
+import java.util.{ UUID => jUUID }
+
+case class NamespacedUUID(value: UUID)
+
+object NamespacedUUID {
+  private val nullUUID = UUID.fromUUID(jUUID.fromString("00000000-0000-0000-0000-000000000000"))
+  val ubirchUUID: UUID = UUID.V5.apply(nullUUID, "ubirch")
+
+  def fromJavaUUID(uuid: jUUID): NamespacedUUID = NamespacedUUID(UUID.fromUUID(uuid))
+
+  implicit val encodeNamespacedUUID: MappedEncoding[NamespacedUUID, jUUID] =
+    MappedEncoding[NamespacedUUID, jUUID](_.value.asJava())
+  implicit val decodeNamespacedUUID: MappedEncoding[jUUID, NamespacedUUID] =
+    MappedEncoding[jUUID, NamespacedUUID](uuid => NamespacedUUID.fromJavaUUID(uuid))
+}

--- a/src/main/scala/com/ubirch/models/poc/DeviceId.scala
+++ b/src/main/scala/com/ubirch/models/poc/DeviceId.scala
@@ -1,0 +1,20 @@
+package com.ubirch.models.poc
+import com.ubirch.models.NamespacedUUID
+import com.ubirch.models.tenant.TenantId
+import io.getquill.MappedEncoding
+import memeid4s.UUID
+
+import java.util.{ UUID => jUUID }
+
+final case class DeviceId private (value: NamespacedUUID) extends AnyVal
+
+object DeviceId {
+
+  def apply(tenantId: TenantId, externalId: String) =
+    new DeviceId(NamespacedUUID(UUID.V5(tenantId.value.value, externalId)))
+
+  implicit val encodeTenantId: MappedEncoding[DeviceId, jUUID] =
+    MappedEncoding[DeviceId, jUUID](_.value.value.asJava())
+  implicit val decodeTenantId: MappedEncoding[jUUID, DeviceId] =
+    MappedEncoding[jUUID, DeviceId](uuid => new DeviceId(NamespacedUUID.fromJavaUUID(uuid)))
+}

--- a/src/main/scala/com/ubirch/models/poc/Poc.scala
+++ b/src/main/scala/com/ubirch/models/poc/Poc.scala
@@ -20,7 +20,7 @@ case class Poc(
   manager: PocManager,
   roleAndGroupName: String,
   groupPath: String,
-  deviceId: UUID = UUID.randomUUID(), //Todo: generate name spaced
+  deviceId: DeviceId,
   clientCertFolder: Option[String] = None,
   status: Status = Pending,
   lastUpdated: Updated = Updated(DateTime.now()),
@@ -45,9 +45,9 @@ object Poc {
     manager: PocManager): Poc = {
     val roleName = s"P_${pocName.take(10)}_$id"
     Poc(
-      id,
+      id = id,
       tenantId = tenantId,
-      externalId,
+      externalId = externalId,
       pocName = pocName,
       address = address,
       phone = phone,
@@ -57,8 +57,9 @@ object Poc {
       dataSchemaId = dataSchemaId,
       extraConfig = extraConfig,
       manager = manager,
-      roleName,
-      tenantGroupName + "/" + roleName
+      roleAndGroupName = roleName,
+      groupPath = tenantGroupName + "/" + roleName,
+      deviceId = DeviceId(tenantId, externalId)
     )
   }
 

--- a/src/main/scala/com/ubirch/models/poc/Poc.scala
+++ b/src/main/scala/com/ubirch/models/poc/Poc.scala
@@ -1,12 +1,13 @@
 package com.ubirch.models.poc
 
+import com.ubirch.models.tenant.TenantId
 import org.joda.time.DateTime
 
 import java.util.UUID
 
 case class Poc(
   id: UUID,
-  tenantId: UUID,
+  tenantId: TenantId,
   externalId: String,
   pocName: String,
   address: Address,
@@ -30,7 +31,7 @@ object Poc {
 
   def apply(
     id: UUID,
-    tenantId: UUID,
+    tenantId: TenantId,
     tenantGroupName: String,
     externalId: String,
     pocName: String,

--- a/src/main/scala/com/ubirch/models/tenant/TenantId.scala
+++ b/src/main/scala/com/ubirch/models/tenant/TenantId.scala
@@ -1,13 +1,19 @@
 package com.ubirch.models.tenant
+import com.ubirch.models.NamespacedUUID
 import io.getquill.MappedEncoding
+import memeid4s.UUID
 
-import java.util.UUID
+import java.util.{ UUID => jUUID }
 
-final case class TenantId(value: UUID) extends AnyVal
+final case class TenantId private (value: NamespacedUUID) extends AnyVal
 
 object TenantId {
-  def random: TenantId = TenantId(UUID.randomUUID())
 
-  implicit val encodeTenantId: MappedEncoding[TenantId, UUID] = MappedEncoding[TenantId, UUID](_.value)
-  implicit val decodeTenantId: MappedEncoding[UUID, TenantId] = MappedEncoding[UUID, TenantId](TenantId(_))
+  def apply(tenantName: TenantName): TenantId =
+    new TenantId(NamespacedUUID(UUID.V5(NamespacedUUID.ubirchUUID, tenantName)))
+
+  implicit val encodeTenantId: MappedEncoding[TenantId, jUUID] =
+    MappedEncoding[TenantId, jUUID](_.value.value.asJava())
+  implicit val decodeTenantId: MappedEncoding[jUUID, TenantId] =
+    MappedEncoding[jUUID, TenantId](uuid => new TenantId(NamespacedUUID.fromJavaUUID(uuid)))
 }

--- a/src/main/scala/com/ubirch/models/tenant/TenantName.scala
+++ b/src/main/scala/com/ubirch/models/tenant/TenantName.scala
@@ -1,9 +1,14 @@
 package com.ubirch.models.tenant
 import io.getquill.MappedEncoding
+import memeid4s.digest.Digestible
+
+import java.nio.charset.StandardCharsets
 
 final case class TenantName(value: String) extends AnyVal
 
 object TenantName {
   implicit val encodeTenantName: MappedEncoding[TenantName, String] = MappedEncoding[TenantName, String](_.value)
   implicit val decodeTenantName: MappedEncoding[String, TenantName] = MappedEncoding[String, TenantName](TenantName(_))
+  implicit val digestibleTenantName: Digestible[TenantName] =
+    (tenantName: TenantName) => tenantName.value.getBytes(StandardCharsets.UTF_8)
 }

--- a/src/main/scala/com/ubirch/services/poc/CsvHandler.scala
+++ b/src/main/scala/com/ubirch/services/poc/CsvHandler.scala
@@ -108,10 +108,9 @@ class CsvPocBatchParserImp extends CsvPocBatchParserTrait with LazyLogging {
         extraConfig,
         manager) =>
         {
-          val id = UUID.randomUUID() //Todo: create namespaced UUID?
           poc.Poc(
-            id,
-            tenant.id.value,
+            UUID.randomUUID(),
+            tenant.id,
             tenant.groupId.value,
             externalId,
             pocName,

--- a/src/main/scala/com/ubirch/services/superadmin/TenantService.scala
+++ b/src/main/scala/com/ubirch/services/superadmin/TenantService.scala
@@ -29,7 +29,7 @@ class DefaultTenantService @Inject() (aesEncryption: AESEncryption, tenantReposi
     encryptedCertificationCreationToken: EncryptedCertificationCreationToken,
     createTenantRequest: CreateTenantRequest): Tenant =
     Tenant(
-      TenantId.random,
+      TenantId(createTenantRequest.tenantName),
       createTenantRequest.tenantName,
       createTenantRequest.usageType,
       encryptedDeviceCreationToken,

--- a/src/test/scala/com/ubirch/InjectorHelperImpl.scala
+++ b/src/test/scala/com/ubirch/InjectorHelperImpl.scala
@@ -27,6 +27,7 @@ import java.security.Key
 import javax.inject.{ Inject, Singleton }
 import com.ubirch.crypto.{ GeneratorKeyFactory, PrivKey }
 import com.ubirch.db.tables.{ TenantRepository, TenantTestTable, UserRepository, UserTestTable }
+import com.ubirch.models.tenant.TenantName
 import com.ubirch.services.{ DeviceKeycloak, KeycloakInstance, UsersKeycloak }
 import com.ubirch.services.jwt.{
   DefaultPublicKeyPoolService,
@@ -146,49 +147,49 @@ object FakeToken {
       |  "email": "carlos.sanchez@ubirch.com"
       |}""".stripMargin
 
-  val tenantAdmin: String =
-    """
-      |{
-      |  "exp": 1718338181,
-      |  "iat": 1604336381,
-      |  "jti": "2fb1c61d-2113-4b8e-9432-97c28c697b98",
-      |  "iss": "https://id.dev.ubirch.com/auth/realms/ubirch-default-realm",
-      |  "aud": "account",
-      |  "sub": "963995ed-ce12-4ea5-89dc-b181701d1d7b",
-      |  "typ": "Bearer",
-      |  "azp": "ubirch-2.0-user-access",
-      |  "session_state": "f334122a-4693-4826-a2c0-546391886eda",
-      |  "acr": "1",
-      |  "allowed-origins": [
-      |    "http://localhost:9101",
-      |    "https://console.dev.ubirch.com"
-      |  ],
-      |  "realm_access": {
-      |    "roles": [
-      |      "tenant-admin",
-      |      "T_tenantName",
-      |    ]
-      |  },
-      |  "resource_access": {
-      |    "account": {
-      |      "roles": [
-      |        "manage-account",
-      |        "manage-account-links",
-      |        "view-profile",
-      |      ]
-      |    }
-      |  },
-      |  "scope": "fav_color profile email",
-      |  "email_verified": true,
-      |  "fav_fruit": [
-      |    "/OWN_DEVICES_carlos.sanchez@ubirch.com"
-      |  ],
-      |  "name": "Carlos Sanchez",
-      |  "preferred_username": "carlos.sanchez@ubirch.com",
-      |  "given_name": "Carlos",
-      |  "family_name": "Sanchez",
-      |  "email": "carlos.sanchez@ubirch.com"
-      |}""".stripMargin
+  def tenantAdmin(tenantName: TenantName): String =
+    s"""
+       |{
+       |  "exp": 1718338181,
+       |  "iat": 1604336381,
+       |  "jti": "2fb1c61d-2113-4b8e-9432-97c28c697b98",
+       |  "iss": "https://id.dev.ubirch.com/auth/realms/ubirch-default-realm",
+       |  "aud": "account",
+       |  "sub": "963995ed-ce12-4ea5-89dc-b181701d1d7b",
+       |  "typ": "Bearer",
+       |  "azp": "ubirch-2.0-user-access",
+       |  "session_state": "f334122a-4693-4826-a2c0-546391886eda",
+       |  "acr": "1",
+       |  "allowed-origins": [
+       |    "http://localhost:9101",
+       |    "https://console.dev.ubirch.com"
+       |  ],
+       |  "realm_access": {
+       |    "roles": [
+       |      "tenant-admin",
+       |      "T_${tenantName.value}",
+       |    ]
+       |  },
+       |  "resource_access": {
+       |    "account": {
+       |      "roles": [
+       |        "manage-account",
+       |        "manage-account-links",
+       |        "view-profile",
+       |      ]
+       |    }
+       |  },
+       |  "scope": "fav_color profile email",
+       |  "email_verified": true,
+       |  "fav_fruit": [
+       |    "/OWN_DEVICES_carlos.sanchez@ubirch.com"
+       |  ],
+       |  "name": "Carlos Sanchez",
+       |  "preferred_username": "carlos.sanchez@ubirch.com",
+       |  "given_name": "Carlos",
+       |  "family_name": "Sanchez",
+       |  "email": "carlos.sanchez@ubirch.com"
+       |}""".stripMargin
 
   val superAdmin: String =
     """
@@ -396,7 +397,8 @@ class FakeTokenCreator @Inject() (tokenCreationService: TokenCreationService) {
   }
 
   val user: FakeToken = fakeToken(FakeToken.usersHeader, FakeToken.user, UsersKeycloak)
-  val userOnDevicesKeycloak: FakeToken = fakeToken(FakeToken.deviceHeader, FakeToken.tenantAdmin, DeviceKeycloak)
+  def userOnDevicesKeycloak(tenantName: TenantName): FakeToken =
+    fakeToken(FakeToken.deviceHeader, FakeToken.tenantAdmin(tenantName), DeviceKeycloak)
   val superAdmin: FakeToken = fakeToken(FakeToken.deviceHeader, FakeToken.superAdmin, DeviceKeycloak)
   val superAdminOnUsersKeycloak: FakeToken = fakeToken(FakeToken.usersHeader, FakeToken.superAdmin, UsersKeycloak)
   val userWithDoubleRoles: FakeToken = fakeToken(FakeToken.usersHeader, FakeToken.userWithDoubleRoles, UsersKeycloak)

--- a/src/test/scala/com/ubirch/InjectorHelperImpl.scala
+++ b/src/test/scala/com/ubirch/InjectorHelperImpl.scala
@@ -5,6 +5,7 @@ import com.typesafe.config.Config
 import com.ubirch.crypto.utils.Curve
 import com.ubirch.crypto.{ GeneratorKeyFactory, PrivKey }
 import com.ubirch.db.tables.{ TenantRepository, TenantTestTable, UserRepository, UserTestTable }
+import com.ubirch.models.tenant.TenantName
 import com.ubirch.services.jwt.{
   DefaultPublicKeyPoolService,
   PublicKeyDiscoveryService,
@@ -21,33 +22,11 @@ import com.ubirch.services.keycloak.users.{
   UserPollingService
 }
 import com.ubirch.services.{ DeviceKeycloak, KeycloakInstance, UsersKeycloak }
+import com.ubirch.util.ServiceConstants.TENANT_GROUP_PREFIX
 import monix.eval.Task
 
 import java.security.Key
 import javax.inject.{ Inject, Singleton }
-import com.ubirch.crypto.{ GeneratorKeyFactory, PrivKey }
-import com.ubirch.db.tables.{ TenantRepository, TenantTestTable, UserRepository, UserTestTable }
-import com.ubirch.models.tenant.TenantName
-import com.ubirch.services.{ DeviceKeycloak, KeycloakInstance, UsersKeycloak }
-import com.ubirch.services.jwt.{
-  DefaultPublicKeyPoolService,
-  PublicKeyDiscoveryService,
-  PublicKeyPoolService,
-  TokenCreationService
-}
-import com.ubirch.services.keycloak.auth.{ AuthClient, TestAuthClient }
-import com.ubirch.services.keycloak.groups.{ KeycloakGroupService, TestKeycloakGroupsService }
-import com.ubirch.services.keycloak.roles.{ KeycloakRolesService, TestKeycloakRolesService }
-import com.ubirch.services.keycloak.users.{
-  KeycloakUserService,
-  TestKeycloakUserService,
-  TestUserPollingService,
-  UserPollingService
-}
-import monix.eval.Task
-
-import java.security.Key
-import javax.inject.{ Inject, Provider, Singleton }
 
 @Singleton
 class FakeDefaultPublicKeyPoolService @Inject() (config: Config, publicKeyDiscoveryService: PublicKeyDiscoveryService)
@@ -167,7 +146,7 @@ object FakeToken {
        |  "realm_access": {
        |    "roles": [
        |      "tenant-admin",
-       |      "T_${tenantName.value}",
+       |      "$TENANT_GROUP_PREFIX${tenantName.value}",
        |    ]
        |  },
        |  "resource_access": {

--- a/src/test/scala/com/ubirch/ModelCreationHelper.scala
+++ b/src/test/scala/com/ubirch/ModelCreationHelper.scala
@@ -6,6 +6,7 @@ import com.ubirch.models.tenant._
 import org.json4s.native.JsonMethods.parse
 
 import java.util.UUID
+import scala.util.Random
 
 object ModelCreationHelper {
 
@@ -14,10 +15,9 @@ object ModelCreationHelper {
   private val encryptedData = EncryptedData(base64String)
   private val deviceCreationToken = EncryptedDeviceCreationToken(encryptedData)
   private val certCreationToken = EncryptedCertificationCreationToken(encryptedData)
-  private val tenantName = "tenantName"
-  def createTenant(id: UUID = UUID.randomUUID(), name: String = tenantName): Tenant = {
+  def createTenant(name: String = Random.alphanumeric.take(10).toList.mkString): Tenant = {
     Tenant(
-      TenantId(id),
+      TenantId(TenantName(name)),
       TenantName(name),
       API,
       deviceCreationToken,
@@ -29,13 +29,12 @@ object ModelCreationHelper {
 
   def createPoc(
     id: UUID = UUID.randomUUID(),
-    tenantId: UUID = UUID.randomUUID(),
-    tenantGroupName: String = s"T_$tenantName",
+    tenantName: TenantName,
     externalId: String = UUID.randomUUID().toString): Poc =
     Poc(
       id,
-      tenantId,
-      tenantGroupName,
+      TenantId(tenantName),
+      s"T_${tenantName.value}",
       externalId,
       "pocName",
       Address("", "", None, 67832, "", None, None, "France"),

--- a/src/test/scala/com/ubirch/ModelCreationHelper.scala
+++ b/src/test/scala/com/ubirch/ModelCreationHelper.scala
@@ -38,7 +38,7 @@ object ModelCreationHelper {
     Poc(
       id,
       TenantId(tenantName),
-      s"$TENANT_GROUP_PREFIX_${tenantName.value}",
+      s"$TENANT_GROUP_PREFIX${tenantName.value}",
       externalId,
       "pocName",
       Address("", "", None, 67832, "", None, None, "France"),

--- a/src/test/scala/com/ubirch/e2e/controllers/TenantAdminControllerSpec.scala
+++ b/src/test/scala/com/ubirch/e2e/controllers/TenantAdminControllerSpec.scala
@@ -6,7 +6,7 @@ import com.ubirch.controllers.TenantAdminController
 import com.ubirch.db.tables.{ PocRepository, PocStatusRepository, PocTable, TenantTable }
 import com.ubirch.e2e.E2ETestBase
 import com.ubirch.models.poc.{ Poc, PocStatus }
-import com.ubirch.models.tenant.TenantId
+import com.ubirch.models.tenant.{ Tenant, TenantId, TenantName }
 import com.ubirch.services.formats.DomainObjectFormats
 import com.ubirch.services.jwt.PublicKeyPoolService
 import com.ubirch.services.poc.util.CsvConstants
@@ -25,7 +25,6 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
 
   private val poc1id: UUID = UUID.randomUUID()
   private val poc2id: UUID = UUID.randomUUID()
-  private val tenantId: UUID = UUID.randomUUID()
   implicit private val formats: Formats =
     DefaultFormats.lossless ++ DomainObjectFormats.all ++ JavaTypesSerializers.all ++ JodaTimeSerializers.all
 
@@ -43,16 +42,16 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
     "return success without invalid rows" in {
       withInjector { Injector =>
         val token = Injector.get[FakeTokenCreator]
-        addTenantToDB()
+        val tenant = addTenantToDB()
         post(
           "/pocs/create",
           body = goodCsv.getBytes(),
-          headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+          headers = Map("authorization" -> token.userOnDevicesKeycloak(tenant.tenantName).prepare)) {
           status should equal(200)
           assert(body.isEmpty)
         }
         val repo = Injector.get[PocRepository]
-        val pocs = await(repo.getAllPocsByTenantId(tenantId), 5.seconds)
+        val pocs = await(repo.getAllPocsByTenantId(tenant.id), 5.seconds)
         pocs.map(_.externalId shouldBe poc1id.toString)
       }
     }
@@ -74,7 +73,7 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
         post(
           "/pocs/create",
           body = badCsv.getBytes(),
-          headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+          headers = Map("authorization" -> token.userOnDevicesKeycloak(TenantName("tenantName")).prepare)) {
           status should equal(400)
           assert(body == "NOK(1.0,false,'AuthenticationError,couldn't find tenant in db for T_tenantName)")
         }
@@ -84,11 +83,11 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
     "return invalid csv rows" in {
       withInjector { Injector =>
         val token = Injector.get[FakeTokenCreator]
-        addTenantToDB()
+        val tenant = addTenantToDB()
         post(
           "/pocs/create",
           body = badCsv.getBytes(),
-          headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+          headers = Map("authorization" -> token.userOnDevicesKeycloak(tenant.tenantName).prepare)) {
           status should equal(200)
           assert(body == CsvConstants.headerErrorMsg("poc_id*", CsvConstants.externalId))
         }
@@ -110,7 +109,9 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
         }
         val storedStatus = await(res1, 5.seconds).get
         storedStatus shouldBe pocStatus.copy(lastUpdated = storedStatus.lastUpdated)
-        get(s"/pocStatus/${pocStatus.pocId}", headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+        get(
+          s"/pocStatus/${pocStatus.pocId}",
+          headers = Map("authorization" -> token.userOnDevicesKeycloak(TenantName("tenant")).prepare)) {
           status should equal(200)
           assert(body == write[PocStatus](storedStatus))
         }
@@ -121,7 +122,9 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
       withInjector { Injector =>
         val token = Injector.get[FakeTokenCreator]
         val randomID = UUID.randomUUID()
-        get(s"/pocStatus/$randomID", headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+        get(
+          s"/pocStatus/$randomID",
+          headers = Map("authorization" -> token.userOnDevicesKeycloak(TenantName("tenant")).prepare)) {
           status should equal(404)
           assert(body == s"NOK(1.0,false,'ResourceNotFoundError,pocStatus with $randomID couldn't be found)")
         }
@@ -134,18 +137,20 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
       withInjector { Injector =>
         val token = Injector.get[FakeTokenCreator]
         val pocTable = Injector.get[PocRepository]
-        addTenantToDB()
+        val tenant = addTenantToDB()
         val r = for {
-          _ <- pocTable.createPoc(createPoc(poc1id, tenantId))
-          _ <- pocTable.createPoc(createPoc(poc2id, tenantId))
-          _ <- pocTable.createPoc(createPoc(UUID.randomUUID(), UUID.randomUUID()))
-          pocs <- pocTable.getAllPocsByTenantId(tenantId)
+          _ <- pocTable.createPoc(createPoc(poc1id, tenant.tenantName))
+          _ <- pocTable.createPoc(createPoc(poc2id, tenant.tenantName))
+          _ <- pocTable.createPoc(createPoc(
+            UUID.randomUUID(),
+            TenantName("other tenant")))
+          pocs <- pocTable.getAllPocsByTenantId(tenant.id)
         } yield {
           pocs
         }
         val pocs = await(r, 5.seconds)
         pocs.size shouldBe 2
-        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak(tenant.tenantName).prepare)) {
           status should equal(200)
           body shouldBe write[List[Poc]](pocs)
         }
@@ -155,7 +160,7 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
     "return Bad Request when tenant doesn't exist" in {
       withInjector { Injector =>
         val token = Injector.get[FakeTokenCreator]
-        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak(TenantName("tenantName")).prepare)) {
           println(body)
           status should equal(400)
           assert(body == "NOK(1.0,false,'AuthenticationError,couldn't find tenant in db for T_tenantName)")
@@ -165,9 +170,9 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
 
     "return Success also when list of PoCs is empty" in {
       withInjector { Injector =>
-        addTenantToDB()
+        val tenant = addTenantToDB()
         val token = Injector.get[FakeTokenCreator]
-        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak.prepare)) {
+        get(s"/pocs", headers = Map("authorization" -> token.userOnDevicesKeycloak(tenant.tenantName).prepare)) {
           status should equal(200)
           body shouldBe "[]"
         }
@@ -201,11 +206,12 @@ class TenantAdminControllerSpec extends E2ETestBase with BeforeAndAfterEach with
     }
   }
 
-  private def addTenantToDB(): TenantId = {
+  private def addTenantToDB(): Tenant = {
     withInjector { injector =>
       val tenantTable = injector.get[TenantTable]
-      val tenant = createTenant(tenantId)
+      val tenant = createTenant()
       await(tenantTable.createTenant(tenant), 5.seconds)
+      tenant
     }
   }
 

--- a/src/test/scala/com/ubirch/e2e/db/PocTableTest.scala
+++ b/src/test/scala/com/ubirch/e2e/db/PocTableTest.scala
@@ -2,9 +2,9 @@ package com.ubirch.e2e.db
 
 import com.ubirch.ModelCreationHelper.{ createPoc, createPocStatus }
 import com.ubirch.db.tables.{ PocRepository, PocStatusRepository }
-import com.ubirch.db.tables.{ PocRepository, PocStatusRepository }
 import com.ubirch.e2e.E2ETestBase
 import com.ubirch.models.poc._
+import com.ubirch.models.tenant.TenantName
 import org.postgresql.util.PSQLException
 
 import java.util.UUID
@@ -16,7 +16,7 @@ class PocTableTest extends E2ETestBase {
     "be able to store and retrieve data in DB" in {
       withInjector { injector =>
         val repo = injector.get[PocRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val res = for {
           _ <- repo.createPoc(poc)
           data <- repo.getPoc(poc.id)
@@ -29,7 +29,7 @@ class PocTableTest extends E2ETestBase {
     "fail when same Poc is tried to be stored twice, when unique constraint is violated" in {
       withInjector { injector =>
         val repo = injector.get[PocRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val res = for {
           _ <- repo.createPoc(poc)
           _ <- repo.createPoc(poc.copy(UUID.randomUUID()))
@@ -44,7 +44,7 @@ class PocTableTest extends E2ETestBase {
     "fail when same Poc is tried to be stored twice, when only primary key is the same" in {
       withInjector { injector =>
         val repo = injector.get[PocRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val res = for {
           _ <- repo.createPoc(poc)
           _ <- repo.createPoc(poc.copy(dataSchemaId = "x"))
@@ -59,7 +59,7 @@ class PocTableTest extends E2ETestBase {
     "be able to store and update data in DB" in {
       withInjector { injector =>
         val repo = injector.get[PocRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val updatedPoc = poc.copy(dataSchemaId = "xxx")
 
         val res1 = for {
@@ -77,7 +77,7 @@ class PocTableTest extends E2ETestBase {
     "be able to store and delete data in DB" in {
       withInjector { injector =>
         val repo = injector.get[PocRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val res1 = for {
           _ <- repo.createPoc(poc)
           data <- repo.getPoc(poc.id)
@@ -100,7 +100,7 @@ class PocTableTest extends E2ETestBase {
       withInjector { injector =>
         val pocRepo = injector.get[PocRepository]
         val statusRepo = injector.get[PocStatusRepository]
-        val poc = createPoc()
+        val poc = createPoc(tenantName = TenantName("tenant"))
         val pocStatus = createPocStatus(poc.id)
 
         val poc1 = poc.copy(UUID.randomUUID(), pocName = "new name")

--- a/src/test/scala/com/ubirch/models/NamespacedUUIDTest.scala
+++ b/src/test/scala/com/ubirch/models/NamespacedUUIDTest.scala
@@ -1,0 +1,16 @@
+package com.ubirch.models
+import com.ubirch.UnitTestBase
+import memeid4s.UUID
+
+import java.util.{ UUID => jUUID }
+
+class NamespacedUUIDTest extends UnitTestBase {
+
+  "Ubirch UUID" should {
+    "be namespaced with 'ubirch' name and created from only 0's UUID" in {
+      val expectedUUID = UUID.V5(UUID.fromUUID(jUUID.fromString("00000000-0000-0000-0000-000000000000")), "ubirch")
+      NamespacedUUID.ubirchUUID shouldBe expectedUUID
+    }
+  }
+
+}

--- a/src/test/scala/com/ubirch/models/poc/DeviceIdTest.scala
+++ b/src/test/scala/com/ubirch/models/poc/DeviceIdTest.scala
@@ -1,0 +1,30 @@
+package com.ubirch.models.poc
+import com.ubirch.UnitTestBase
+import com.ubirch.models.tenant.{ TenantId, TenantName }
+
+class DeviceIdTest extends UnitTestBase {
+
+  "Creation of DeviceId" should {
+    "result in same UUID if provided with same tenantId and externalId" in {
+      val deviceId1 = DeviceId(TenantId(TenantName("name")), "1")
+      val deviceId2 = DeviceId(TenantId(TenantName("name")), "1")
+
+      deviceId1 shouldBe deviceId2
+    }
+
+    "result in different UUID if provided with same tenantId but different externalId" in {
+      val deviceId1 = DeviceId(TenantId(TenantName("name")), "1")
+      val deviceId2 = DeviceId(TenantId(TenantName("name")), "2")
+
+      deviceId1 shouldNot be(deviceId2)
+    }
+
+    "result in different UUID if provided with different tenantId but same externalId" in {
+      val deviceId1 = DeviceId(TenantId(TenantName("name1")), "1")
+      val deviceId2 = DeviceId(TenantId(TenantName("name2")), "1")
+
+      deviceId1 shouldNot be(deviceId2)
+    }
+  }
+
+}

--- a/src/test/scala/com/ubirch/models/tenant/TenantIdTest.scala
+++ b/src/test/scala/com/ubirch/models/tenant/TenantIdTest.scala
@@ -1,6 +1,8 @@
 package com.ubirch.models.tenant
 import com.ubirch.UnitTestBase
 
+import scala.util.Random
+
 class TenantIdTest extends UnitTestBase {
 
   "TenantID" should {
@@ -19,6 +21,11 @@ class TenantIdTest extends UnitTestBase {
       val tenantId2 = TenantId(TenantName("name_2"))
 
       tenantId1 shouldNot be(tenantId2)
+    }
+
+    "be able to be created even if TenantName is extra long string" in {
+      val tenantName = TenantName(Random.alphanumeric.take(2000).mkString)
+      TenantId(tenantName)
     }
   }
 

--- a/src/test/scala/com/ubirch/models/tenant/TenantIdTest.scala
+++ b/src/test/scala/com/ubirch/models/tenant/TenantIdTest.scala
@@ -1,0 +1,25 @@
+package com.ubirch.models.tenant
+import com.ubirch.UnitTestBase
+
+class TenantIdTest extends UnitTestBase {
+
+  "TenantID" should {
+    "create always same TenantID if provided with same TenantName" in {
+      val tenantName = TenantName("name_1")
+      val tenantId1 = TenantId(tenantName)
+      val tenantId2 = TenantId(tenantName)
+      val tenantId3 = TenantId(tenantName)
+
+      tenantId1 shouldBe tenantId2
+      tenantId2 shouldBe tenantId3
+    }
+
+    "create different TenantIDs if provided with different TenantNames" in {
+      val tenantId1 = TenantId(TenantName("name_1"))
+      val tenantId2 = TenantId(TenantName("name_2"))
+
+      tenantId1 shouldNot be(tenantId2)
+    }
+  }
+
+}


### PR DESCRIPTION
UbirchID, TenantId and DeviceID are Namespaced UUIDs from now on.

UbirchID is created by using "00000000-0000-0000-0000-000000000000" UUID and "ubirch" string as name.
TenantID is created by using UbirchID as UUID and `TenantName` as name.
DeviceID is created by using TenantID as UUID and `externalId` as name.