### PR TITLE
UNG-2412 - readiness and liveness endpoints

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,5 +1,6 @@
 import com.ubirch.Service
 import com.ubirch.controllers.{
+  HealthChecksController,
   InfoController,
   PocAdminController,
   PocEmployeeController,
@@ -21,6 +22,7 @@ class ScalatraBootstrap extends LifeCycle {
     lazy val pocAdminController = Service.get[PocAdminController]
     lazy val resourcesController = Service.get[ResourcesController]
     lazy val pocEmployeeController = Service.get[PocEmployeeController]
+    lazy val healthCheckController = Service.get[HealthChecksController]
 
     context.setInitParameter("org.scalatra.cors.preflightMaxAge", "5")
     context.setInitParameter("org.scalatra.cors.allowCredentials", "false")
@@ -55,6 +57,11 @@ class ScalatraBootstrap extends LifeCycle {
       handler = resourcesController,
       urlPattern = "/api-docs",
       name = "Resources"
+    )
+    context.mount(
+      handler = healthCheckController,
+      urlPattern = "/health-check",
+      name = "health-check"
     )
   }
 

--- a/src/main/scala/com/ubirch/Binder.scala
+++ b/src/main/scala/com/ubirch/Binder.scala
@@ -12,6 +12,7 @@ import com.ubirch.services.clock.ClockProvider
 import com.ubirch.services.config.ConfigProvider
 import com.ubirch.services.execution.{ ExecutionProvider, SchedulerProvider }
 import com.ubirch.services.formats.{ DefaultJsonConverterService, JsonConverterService, JsonFormatsProvider }
+import com.ubirch.services.healthcheck.{ DefaultHealthCheckService, HealthCheckService }
 import com.ubirch.services.jwt._
 import com.ubirch.services.keycloak._
 import com.ubirch.services.keycloak.groups.{ DefaultKeycloakGroupService, KeycloakGroupService }
@@ -212,6 +213,12 @@ class Binder extends AbstractModule {
   def PocEmployeeService: ScopedBindingBuilder =
     bind(classOf[PocEmployeeService]).to(classOf[PocEmployeeServiceImpl])
 
+  def HealthCheckRepository: ScopedBindingBuilder =
+    bind(classOf[HealthCheckRepository]).to(classOf[DefaultHealthCheckRepository])
+
+  def HealthCheckService: ScopedBindingBuilder =
+    bind(classOf[HealthCheckService]).to(classOf[DefaultHealthCheckService])
+
   override def configure(): Unit = {
     Config
     Clock
@@ -277,6 +284,8 @@ class Binder extends AbstractModule {
     CsvProcessPocEmployee
     ImageLoader
     PocEmployeeService
+    HealthCheckRepository
+    HealthCheckService
     ()
   }
 }

--- a/src/main/scala/com/ubirch/controllers/HealthChecksController.scala
+++ b/src/main/scala/com/ubirch/controllers/HealthChecksController.scala
@@ -1,0 +1,51 @@
+package com.ubirch.controllers
+import com.typesafe.config.Config
+import com.ubirch.ConfPaths.GenericConfPaths
+import com.ubirch.controllers.concerns.ControllerBase
+import com.ubirch.services.healthcheck.{ HealthCheckService, NotOperational, Operational }
+import io.prometheus.client.Counter
+import monix.execution.Scheduler
+import org.json4s.Formats
+import org.scalatra.{ Ok, ServiceUnavailable }
+import org.scalatra.swagger.Swagger
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class HealthChecksController @Inject() (
+  config: Config,
+  val swagger: Swagger,
+  jFormats: Formats,
+  healthCheckService: HealthCheckService
+)(implicit val executor: ExecutionContext, scheduler: Scheduler)
+  extends ControllerBase {
+
+  override def service: String = config.getString(GenericConfPaths.NAME)
+
+  override def successCounter: Counter = Counter
+    .build()
+    .name("health_checks_success")
+    .help("Represents the number of health checks controller successes")
+    .labelNames("service", "method")
+    .register()
+  override def errorCounter: Counter = Counter
+    .build()
+    .name("health_checks_failures")
+    .help("Represents the number of health checks controller failures")
+    .labelNames("service", "method")
+    .register()
+  override protected def applicationDescription: String = "Health Checks Controller"
+  implicit override protected def jsonFormats: Formats = jFormats
+
+  get("/liveness") {
+    Ok()
+  }
+
+  get("/readiness") {
+    healthCheckService.performAllHealthChecks().map {
+      case NotOperational => ServiceUnavailable()
+      case Operational    => Ok()
+    }.runToFuture
+  }
+
+}

--- a/src/main/scala/com/ubirch/db/tables/HealthCheckRepository.scala
+++ b/src/main/scala/com/ubirch/db/tables/HealthCheckRepository.scala
@@ -1,0 +1,25 @@
+package com.ubirch.db.tables
+import com.ubirch.db.context.QuillMonixJdbcContext
+import monix.eval.Task
+
+import javax.inject.Inject
+
+trait HealthCheckRepository {
+  def healthCheck(): Task[Unit]
+}
+
+class DefaultHealthCheckRepository @Inject() (quillMonixJdbcContext: QuillMonixJdbcContext)
+  extends HealthCheckRepository {
+  import quillMonixJdbcContext.ctx._
+
+  private def healthCheckQuery =
+    quote {
+      infix"SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = 'poc_manager')".as[Boolean]
+    }
+
+  override def healthCheck(): Task[Unit] =
+    run(healthCheckQuery).flatMap {
+      case true  => Task.unit
+      case false => Task.raiseError(new RuntimeException("Could not find poc_manager schema"))
+    }
+}

--- a/src/main/scala/com/ubirch/services/healthcheck/HealthCheckService.scala
+++ b/src/main/scala/com/ubirch/services/healthcheck/HealthCheckService.scala
@@ -1,0 +1,111 @@
+package com.ubirch.services.healthcheck
+import com.typesafe.scalalogging.LazyLogging
+import com.ubirch.db.tables.HealthCheckRepository
+import com.ubirch.services.jwt.PublicKeyPoolService
+import com.ubirch.services.keycloak._
+import com.ubirch.services.teamdrive.model.TeamDriveClient
+import com.ubirch.services.{ CertifyKeycloak, DeviceKeycloak, KeycloakConnector, KeycloakInstance }
+import monix.eval.Task
+
+import javax.inject.Inject
+import scala.concurrent.duration.DurationInt
+
+trait HealthCheckService {
+  def performAllHealthChecks(): Task[ReadinessStatus]
+}
+
+class DefaultHealthCheckService @Inject() (
+  healthCheckRepository: HealthCheckRepository,
+  publicKeyPoolService: PublicKeyPoolService,
+  keycloakCertifyConfig: KeycloakCertifyConfig,
+  keycloakDeviceConfig: KeycloakDeviceConfig,
+  keycloakConnector: KeycloakConnector,
+  teamDriveClient: TeamDriveClient
+) extends HealthCheckService
+  with LazyLogging {
+  override def performAllHealthChecks(): Task[ReadinessStatus] = {
+
+    val postgresHealthCheck: Task[Service] = performPostgresHealthCheck()
+    val kidsHealthCheck = Task.pure(checkIfKidsAreAvailable())
+    val certifyDefaultRealmHealthCheck =
+      keycloakHealthCheck(keycloakConnector, CertifyKeycloak, CertifyDefaultRealm)
+    val certifyBmgRealmHealthCheck =
+      keycloakHealthCheck(keycloakConnector, CertifyKeycloak, CertifyBmgRealm)
+    val certifyUbirchRealmHealthCheck =
+      keycloakHealthCheck(keycloakConnector, CertifyKeycloak, CertifyUbirchRealm)
+    val deviceDefaultRealmHealthCheck =
+      keycloakHealthCheck(keycloakConnector, DeviceKeycloak, DeviceDefaultRealm)
+    val teamDriveHealthCheck = performTeamDriveHealthCheck()
+
+    Task.gather(List(
+      postgresHealthCheck,
+      kidsHealthCheck,
+      certifyDefaultRealmHealthCheck,
+      certifyBmgRealmHealthCheck,
+      certifyUbirchRealmHealthCheck,
+      deviceDefaultRealmHealthCheck,
+      teamDriveHealthCheck
+    )).map(Services).map(_.toReadinessStatus)
+  }
+
+  private def performTeamDriveHealthCheck() = {
+    teamDriveClient.getLoginInformation().map(_ => HealthyService).onErrorHandle {
+      case ex: Exception =>
+        logger.error(s"TeamDrive health check returned error: ${ex.getMessage}")
+        UnhealthyService
+    }
+  }
+
+  private def keycloakHealthCheck(
+    keycloakConnector: KeycloakConnector,
+    keycloakInstance: KeycloakInstance,
+    keycloakRealm: KeycloakRealm) = {
+    Task(keycloakConnector.getKeycloak(keycloakInstance).realm(keycloakRealm.name).toRepresentation).map(_ =>
+      HealthyService).onErrorHandle {
+      case ex: Exception =>
+        logger.error(s"Keycloak Healthcheck for realm $keycloakRealm returned error: ${ex.getMessage}")
+        UnhealthyService
+    }
+  }
+
+  private def performPostgresHealthCheck() = {
+    healthCheckRepository.healthCheck().timeout(1.second).map(_ => HealthyService).onErrorHandle {
+      case exception: Exception =>
+        logger.error(s"Postgres Health Check returned error: ${exception.getMessage}", exception)
+        UnhealthyService
+    }
+  }
+
+  private def checkIfKidsAreAvailable() = {
+    val certifyKid = publicKeyPoolService.getKey(keycloakCertifyConfig.acceptedKid)
+    val deviceKid = publicKeyPoolService.getKey(keycloakDeviceConfig.acceptedKid)
+
+    (certifyKid, deviceKid) match {
+      case (Some(_), Some(_)) => HealthyService
+      case (None, None) =>
+        logger.error("Could not find keycloak keys (by kids defined in config file) for certify and device keycloaks")
+        UnhealthyService
+      case (None, _) =>
+        logger.error("Could not find key (by kid defined in the config file) for certify keycloak")
+        UnhealthyService
+      case (_, None) =>
+        logger.error("Could not find key (by kid defined in the config file) for device keycloak")
+        UnhealthyService
+    }
+  }
+}
+
+sealed trait ReadinessStatus extends Product with Serializable
+case object NotOperational extends ReadinessStatus
+case object Operational extends ReadinessStatus
+
+sealed trait Service
+case object HealthyService extends Service
+case object UnhealthyService extends Service
+
+case class Services(services: List[Service]) {
+  def toReadinessStatus: ReadinessStatus = services.find {
+    case HealthyService   => false
+    case UnhealthyService => true
+  }.map(_ => NotOperational).getOrElse(Operational)
+}


### PR DESCRIPTION
Liveness endpoint returns Ok once service is able to handle requests

Readiness endpoint checks:
* Postgres connection and if poc_manager schema exists
* Verifies that there are keys in keycloak for provided kid's in config file
* Verifies that 4 Keycloak realms are reachable and that they are present
* Communication with TeamDrive
If all of the checks pass, then we return 200, otherwise 503