### PR TITLE
UNG-2362 - remove 2FA

### DIFF
--- a/src/main/scala/com/ubirch/services/keycloak/users/KeycloakUserService.scala
+++ b/src/main/scala/com/ubirch/services/keycloak/users/KeycloakUserService.scala
@@ -9,7 +9,8 @@ import com.ubirch.models.user.{ UserId, UserName }
 import com.ubirch.services.keycloak.KeycloakRealm
 import com.ubirch.services.{ DeviceKeycloak, KeycloakConnector, KeycloakInstance }
 import monix.eval.Task
-import org.keycloak.representations.idm.UserRepresentation
+import org.keycloak.representations.idm.{ CredentialRepresentation, UserRepresentation }
+import scala.util.Try
 
 import java.util.UUID
 import javax.ws.rs.core.Response
@@ -284,21 +285,59 @@ class DefaultKeycloakUserService @Inject() (keycloakConnector: KeycloakConnector
     realm: KeycloakRealm,
     id: UUID,
     instance: KeycloakInstance): Task[Either[Remove2faTokenKeycloakError, Unit]] =
-    getUserById(realm, UserId(id), instance).flatMap {
-      case Some(ur) => update(
+    Task.parZip2(getUserById(realm, UserId(id), instance), getUserCredentials(realm, UserId(id), instance)).flatMap {
+      case (Some(ur), credentials) => {
+        val webAuthNCredentials = credentials.find(_.getType == "webauthn")
+        update(
           realm,
           id, {
             ur.setRequiredActions(
-              ur.getRequiredActions.asScala.filterNot(_ == UserRequiredAction.WEBAUTHN_REGISTER.toString).asJava)
+              (ur.getRequiredActions.asScala :+ UserRequiredAction.WEBAUTHN_REGISTER.toString).distinct.asJava
+            )
             ur
           },
-          instance).map(_ => ().asRight)
-      case None => Task.pure(Remove2faTokenKeycloakError.UserNotFound(s"user with id $id wasn't found").asLeft)
+          instance).flatMap(_ => {
+          if (webAuthNCredentials.isDefined) {
+            removeCredentials(realm, UserId(id), instance, webAuthNCredentials.get)
+          } else {
+            Task.unit
+          }
+        }).map(_ => ().asRight)
+      }
+      case _ => Task.pure(Remove2faTokenKeycloakError.UserNotFound(s"user with id $id wasn't found").asLeft)
     }.onErrorHandle { ex =>
       val message = s"Could not remove 2FA token: ${ex.getMessage}"
       logger.error(message, ex)
       Remove2faTokenKeycloakError.KeycloakError(message).asLeft
     }
+
+  private def removeCredentials(
+    realm: KeycloakRealm,
+    userId: UserId,
+    instance: KeycloakInstance,
+    credentials: CredentialRepresentation): Task[Unit] = {
+    Task(
+      keycloakConnector
+        .getKeycloak(instance)
+        .realm(realm.name)
+        .users()
+        .get(userId.value.toString)
+        .removeCredential(credentials.getId)
+    )
+  }
+
+  private def getUserCredentials(realm: KeycloakRealm, userId: UserId, instance: KeycloakInstance) = {
+    Task(
+      Option(keycloakConnector
+        .getKeycloak(instance)
+        .realm(realm.name)
+        .users()
+        .get(userId.value.toString)
+        .credentials()
+        .asScala)
+        .getOrElse(List.empty)
+    )
+  }
 
   private def processCreationResponse(response: Response, userName: String): Either[UserException, UserId] = {
 

--- a/src/test/scala/com/ubirch/e2e/keycloak/KeycloakIntegrationTest.scala
+++ b/src/test/scala/com/ubirch/e2e/keycloak/KeycloakIntegrationTest.scala
@@ -528,12 +528,13 @@ class KeycloakIntegrationTest extends E2ETestBase {
       result._2.value.isEnabled shouldBe true
     }
 
+    // This test does not do too much as we can't test manually performed operations (update password, 2FA).
     "remove 2fa token" in withInjector { injector =>
       val keycloakUserService = injector.get[KeycloakUserService]
       val newKeycloakUser = KeycloakTestData.createNewDeviceKeycloakUser()
       val instance = CertifyKeycloak
       val realm = CertifyKeycloak.defaultRealm
-      val requiredAction = List(UserRequiredAction.UPDATE_PASSWORD, UserRequiredAction.WEBAUTHN_REGISTER)
+      val requiredAction = List(UserRequiredAction.UPDATE_PASSWORD)
 
       val r = for {
         create <- keycloakUserService.createUser(realm, newKeycloakUser, instance, requiredAction)
@@ -554,8 +555,8 @@ class KeycloakIntegrationTest extends E2ETestBase {
       } yield (userRequiredActionsBefore, userRequiredActionsAfter)
       val (requiredActionsBefore, requiredActionsAfter) = await(r)
 
-      requiredActionsBefore should contain theSameElementsAs List("UPDATE_PASSWORD", "webauthn-register")
-      requiredActionsAfter should contain theSameElementsAs List("UPDATE_PASSWORD")
+      requiredActionsBefore should contain theSameElementsAs List("UPDATE_PASSWORD")
+      requiredActionsAfter should contain theSameElementsAs List("UPDATE_PASSWORD", "webauthn-register")
     }
   }
 


### PR DESCRIPTION
To requiredActions we are assigning `WebauthRegister` so next time the user is logging, he will have to assign a new device for 2FA.
We are deleting already existing `webAuthN` credentials so we have only one known device at the time.